### PR TITLE
Fix legacy frontend env var and kea/tftp docker compose files in .env

### DIFF
--- a/kea/.env.dist
+++ b/kea/.env.dist
@@ -22,4 +22,4 @@ COMPOSE_PATH_SEPARATOR=:
 # concat compose files for the required features
 COMPOSE_FILE=docker-compose.neops.kea.prod.yml:docker-compose.neops.tftp.prod.yml
 # kea only
-COMPOSE_FILE=docker-compose.neops.kea.prod.yml
+#COMPOSE_FILE=docker-compose.neops.kea.prod.yml

--- a/neops/docker-compose.neops.prod.yml
+++ b/neops/docker-compose.neops.prod.yml
@@ -61,7 +61,7 @@ services:
       - elasticsearch
       - neops_init
     environment:
-      - FRONTEND_NEOPS_URL=${NEOPS_API_URL:-}
+      FRONTEND_NEOPS_URL: ${NEOPS_API_URL}
     networks:
       - private
 


### PR DESCRIPTION
- Frontend did not use the correct path for graphql, since the variable was set wrong in compose file
- tftp container was not getting started with docker compose in kea folder